### PR TITLE
fix: reduce max page to crawl on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export const config: Config = {
   url: "https://www.builder.io/c/docs/developers",
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
-  maxPagesToCrawl: 1000,
+  maxPagesToCrawl: 5,
   outputFileName: "output.json",
 };
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export const config: Config = {
   url: "https://www.builder.io/c/docs/developers",
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
-  maxPagesToCrawl: 5,
+  maxPagesToCrawl: 50,
   outputFileName: "output.json",
 };
 ```

--- a/config.ts
+++ b/config.ts
@@ -22,6 +22,6 @@ export const config: Config = {
   url: "https://www.builder.io/c/docs/developers",
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
-  maxPagesToCrawl: 1000,
+  maxPagesToCrawl: 5,
   outputFileName: "output.json",
 };

--- a/config.ts
+++ b/config.ts
@@ -22,6 +22,6 @@ export const config: Config = {
   url: "https://www.builder.io/c/docs/developers",
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
-  maxPagesToCrawl: 5,
+  maxPagesToCrawl: 50,
   outputFileName: "output.json",
 };


### PR DESCRIPTION
New use will run with current config to test out the repo.

With 1,000 max page to crawl, if there are traffic on this repo there will be unnecessary heavy load on your server.

So I change max page to crawl from 1,000 to 5.