### PR TITLE
Add `waitForSelectorTimeout` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ type Config = {
     page: Page;
     pushData: (data: any) => Promise<void>;
   }) => Promise<void>;
+    /** Optional timeout for waiting for a selector to appear */
+    waitForSelectorTimeout?: number;
 };
 ```
 

--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,8 @@ type Config = {
     page: Page;
     pushData: (data: any) => Promise<void>;
   }) => Promise<void>;
+    /** Optional timeout for waiting for a selector to appear */
+  waitForSelectorTimeout?: number;
 };
 
 export const config: Config = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ if (process.env.NO_CRAWL !== "true") {
       log.info(`Crawling ${request.loadedUrl}...`);
 
       await page.waitForSelector(config.selector, {
-        timeout: 1000,
+        timeout: config.waitForSelectorTimeout ?? 1000,
       });
 
       const html = await getPageHtml(page);


### PR DESCRIPTION
This PR adds a new optional configuration option, called `waitForSelectorTimeout`. The default timeout remains 1000ms, however users can now override that if-need-be.

It closes #13 