### PR TITLE
Refactor getPageHtml function to handle selector not found case, using body as fallback. Add support for downloading URLs from sitemap.xml. Update comments to let know that sitemap is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the top of the file for the type definition for what you can configure:
 
 ```ts
 type Config = {
-  /** URL to start the crawl */
+  /** URL to start the crawl, if sitemap is providedm then it will be used instead and download all pages in the sitemap */
   url: string;
   /** Pattern to match against for links on a page to subsequently crawl */
   match: string;

--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,7 @@
 import { Page } from "playwright";
 
 type Config = {
-  /** URL to start the crawl */
+  /** URL to start the crawl, could be a sitemap and if so, all pages of the sitemap will be crawled */
   url: string;
   /** Pattern to match against for links on a page to subsequently crawl */
   match: string;
@@ -23,7 +23,7 @@ type Config = {
 };
 
 export const config: Config = {
-  url: "https://www.builder.io/c/docs/developers",
+  url: "https://builder.io/sitemap.xml",
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
   maxPagesToCrawl: 50,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,14 @@ import { Page } from "playwright";
 export function getPageHtml(page: Page) {
   return page.evaluate((selector) => {
     const el = document.querySelector(selector) as HTMLElement | null;
-    return el?.innerText || "";
+    // If the selector is not found, fall back to the body
+    const defaultSelector = "body";
+    if (!el) {
+      console.warn(
+        `Selector "${selector}" not found, falling back to "${defaultSelector}"`
+      );
+    }
+    return el?.innerText ?? document.querySelector(defaultSelector)?.innerText;
   }, config.selector);
 }
 
@@ -32,9 +39,9 @@ if (process.env.NO_CRAWL !== "true") {
       const title = await page.title();
       log.info(`Crawling ${request.loadedUrl}...`);
 
-      await page.waitForSelector(config.selector, {
-        timeout: config.waitForSelectorTimeout ?? 1000,
-      });
+        await page.waitForSelector(config.selector, {
+          timeout: config.waitForSelectorTimeout ?? 1000,
+        });
 
       const html = await getPageHtml(page);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 // For more information, see https://crawlee.dev/
-import { PlaywrightCrawler } from "crawlee";
+import { PlaywrightCrawler, downloadListOfUrls } from "crawlee";
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 import { config } from "../config.js";
@@ -73,8 +73,20 @@ if (process.env.NO_CRAWL !== "true") {
     // headless: false,
   });
 
-  // Add first URL to the queue and start the crawl.
-  await crawler.run([config.url]);
+  const isUrlASitemap = config.url.endsWith("sitemap.xml");
+
+  if (isUrlASitemap) {
+    const listOfUrls = await downloadListOfUrls({ url: config.url });
+
+    // Add the initial URL to the crawling queue.
+    await crawler.addRequests(listOfUrls);
+
+    // Run the crawler
+    await crawler.run();
+  } else {
+    // Add first URL to the queue and start the crawl.
+    await crawler.run([config.url]);
+  }
 }
 
 const jsonFiles = await glob("storage/datasets/default/*.json", {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,18 @@ if (process.env.NO_CRAWL !== "true") {
       const title = await page.title();
       log.info(`Crawling ${request.loadedUrl}...`);
 
+      try {
         await page.waitForSelector(config.selector, {
           timeout: config.waitForSelectorTimeout ?? 1000,
         });
+      } catch (e) {
+        // If the selector is not found, let the user know
+        log.warning(`Selector "${config.selector}" not found on ${request.loadedUrl}, Falling back to "body"`);
+        // using body as a fallback
+        await page.waitForSelector("body", {
+          timeout: config.waitForSelectorTimeout ?? 1000,
+        });
+      }
 
       const html = await getPageHtml(page);
 


### PR DESCRIPTION
This pull request includes several changes to improve the functionality of the code:

1. Refactored the `getPageHtml` function to handle the case when the specified selector is not found on the page. In this case, the function now falls back to using the `body` selector to retrieve the page content.

2. Added a try-catch block to handle the case when the specified selector is not found during the page crawl. If the selector is not found, a warning message is logged and the function falls back to using the `body` selector.

3. Added support for downloading URLs from a sitemap.xml file. If the provided URL is a sitemap, all pages listed in the sitemap will be crawled.

4. Updated comments in the code to indicate that sitemap support has been added.

These changes improve the robustness and flexibility of the code, allowing it to handle cases where the specified selector is not found and enabling the crawling of pages listed in a sitemap.

Fixes #16