### PR TITLE
Added Directory Exclusion

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -20,6 +20,8 @@ type Config = {
   }) => Promise<void>;
     /** Optional timeout for waiting for a selector to appear */
   waitForSelectorTimeout?: number;
+  /** Directories to exclude from crawling */
+  exclude: string[];
 };
 
 export const config: Config = {
@@ -28,4 +30,5 @@ export const config: Config = {
   selector: `.docs-builder-container`,
   maxPagesToCrawl: 50,
   outputFileName: "output.json",
+  exclude: [],
 };


### PR DESCRIPTION
Recursive directory exclusion added and user configurable through config.ts. A list of excluded parent directories is read into an array to be checked against during the crawling process and skipped if found. Pretty quick and dirty and could probably use some optimization. 

Tidied up some related comments as well to make things a little clearer. 