### PR TITLE
chore: support multiple globs in config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -3,7 +3,7 @@ type Config = {
   /** URL to start the crawl */
   url: string;
   /** Pattern to match against for links on a page to subsequently crawl */
-  match: string;
+  match: string | string[];
   /** Selector to grab the inner text from */
   selector: string;
   /** Don't crawl more than this many pages */

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ if (process.env.NO_CRAWL !== "true") {
       // Extract links from the current page
       // and add them to the crawling queue.
       await enqueueLinks({
-        globs: [config.match],
+        globs: typeof config.match === "string" ? [config.match] : config.match,
       });
     },
     // Comment this option to scrape the full website.


### PR DESCRIPTION
Thanks for the great tool!

I encountered a scenario where I needed to pass multiple patterns to the config's match, so I've made the changes. 

I'd appreciate it if you could merge these changes.
