### PR TITLE
add `cross-env` package to avoid Node errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "commander": "^11.1.0",
         "crawlee": "^3.0.0",
+        "cross-env": "^7.0.3",
         "glob": "^10.3.10",
         "inquirer": "^9.2.12",
         "playwright": "*",
@@ -1341,6 +1342,23 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "commander": "^11.1.0",
     "crawlee": "^3.0.0",
+    "cross-env": "^7.0.3",
     "glob": "^10.3.10",
     "inquirer": "^9.2.12",
     "playwright": "*",
@@ -24,8 +25,8 @@
   "scripts": {
     "preinstall": "npx playwright install",
     "start": "npm run start:dev",
-    "start:cli": "NODE_ENV=development npm run build && node dist/src/cli.js",
-    "start:dev": "NODE_ENV=development npm run build && node dist/src/main.js",
+    "start:cli": "cross-env NODE_ENV=development npm run build && node dist/src/cli.js",
+    "start:dev": "cross-env NODE_ENV=development npm run build && node dist/src/main.js",
     "start:prod": "node dist/main.js",
     "build": "tsc",
     "fmt": "prettier --write ."


### PR DESCRIPTION
### Windows users can now just `npm start` instead of 
```
$env:NODE_ENV="development"
npm run build
node dist/src/main.js
```
<br>

I added the `cross-env` package to `package-lock` and `start:dev`, `start:cli` scripts to avoid Node errors with the `NODE_ENV` variable.