### PR TITLE
Adding pagination option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export const defaultConfig: Config = {
   match: "https://www.builder.io/c/docs/**",
   selector: `.docs-builder-container`,
   maxPagesToCrawl: 50,
+  pagesPerPagination: 10,
   outputFileName: "output.json",
 };
 ```
@@ -76,6 +77,8 @@ type Config = {
   selector: string;
   /** Don't crawl more than this many pages */
   maxPagesToCrawl: number;
+  /** Create output files for every number of pages crawled */
+  pagesPerPagination: number;
   /** File name for the finished data */
   outputFileName: string;
   /** Optional resources to exclude 

--- a/config.ts
+++ b/config.ts
@@ -3,6 +3,7 @@ import { Config } from "./src/config";
 export const defaultConfig: Config = {
   url: "https://www.builder.io/c/docs/developers",
   match: "https://www.builder.io/c/docs/**",
-  maxPagesToCrawl: 50,
+  maxPagesToCrawl: 10,
+  pagesPerPagination: 5,
   outputFileName: "output.json",
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,17 +24,20 @@ async function handler(options: Config) {
       match,
       selector,
       maxPagesToCrawl: maxPagesToCrawlStr,
+      pagesPerPagination: pagesPerPaginationStr,
       outputFileName,
     } = options;
 
     // @ts-ignore
     const maxPagesToCrawl = parseInt(maxPagesToCrawlStr, 10);
-
+    // @ts-ignore
+    const pagesPerPagination = parseInt(pagesPerPaginationStr, 10);
     let config: Config = {
       url,
       match,
       selector,
       maxPagesToCrawl,
+      pagesPerPagination,
       outputFileName,
     };
 
@@ -87,6 +90,7 @@ program
   .option("-m, --match <string>", messages.match, "")
   .option("-s, --selector <string>", messages.selector, "")
   .option("-m, --maxPagesToCrawl <number>", messages.maxPagesToCrawl, "50")
+  .option("-p, --pagesPerPagination <number>", "Number of pages to crawl per pagination", "")
   .option(
     "-o, --outputFileName <string>",
     messages.outputFileName,
@@ -95,3 +99,4 @@ program
   .action(handler);
 
 program.parse();
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ const messages = {
   match: "What is the URL pattern you want to match?",
   selector: "What is the CSS selector you want to match?",
   maxPagesToCrawl: "How many pages do you want to crawl?",
+  pagePerPagination: "How many pages do you want to crawl per pagination?",
   outputFileName: "What is the name of the output file?",
 };
 
@@ -90,7 +91,7 @@ program
   .option("-m, --match <string>", messages.match, "")
   .option("-s, --selector <string>", messages.selector, "")
   .option("-m, --maxPagesToCrawl <number>", messages.maxPagesToCrawl, "50")
-  .option("-p, --pagesPerPagination <number>", "Number of pages to crawl per pagination", "")
+  .option("-p, --pagesPerPagination <number>", messages.pagePerPagination, "")
   .option(
     "-o, --outputFileName <string>",
     messages.outputFileName,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,13 @@ export const configSchema = z.object({
    */
   maxPagesToCrawl: z.number().int().positive(),
   /**
+    * Number of pages to crawl per pagination. After crawling this number of pages, 
+    * the results will be written to a new output file. If this field is not provided, 
+    * the application will crawl all pages up to `maxPagesToCrawl` without pagination.
+    * @default undefined
+   */
+  pagesPerPagination: z.number().int().positive().optional(),
+  /**
    * File name for the finished data
    * @default "output.json"
    */
@@ -61,4 +68,5 @@ export const configSchema = z.object({
 });
 
 export type Config = z.infer<typeof configSchema>;
+
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,4 +2,3 @@ import { defaultConfig } from "../config.js";
 import { crawl, write } from "./core.js";
 
 await crawl(defaultConfig);
-await write(defaultConfig);


### PR DESCRIPTION
Adding pagination to the crawler. This is to allow a user to configure how many pages will be crawled per pagination, and then saving this to a modified version of the output file.

The output file will have a number appended which is the paginationCounter.

This PR includes the following changes:

1. Moved all calls to write to the crawl function to handle pagination.
2. Update the filename generation within the write function to handle pagination.
3. Added pagesPerPagination configuration option as optional
4. Update the CLI commands with the pagesPerPagination option
5. Updated the Readme file to reflect the new config option