### PR TITLE
fix: add run swagger js when start server

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "semantic-release": "semantic-release",
     "preinstall": "npx playwright install",
     "start": "npm run start:dev",
-    "start:server": "NODE_ENV=development npm run build && node dist/src/server.js",
+    "start:server": "NODE_ENV=development node swagger.js && npm run build && node dist/src/server.js",
     "start:server:prod": "npm run build && node dist/src/server.js",
     "start:cli": "cross-env NODE_ENV=development npm run build && node dist/src/cli.js",
     "start:dev": "cross-env NODE_ENV=development npm run build && node dist/src/main.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express, {Express} from "express";
+import express, { Express } from "express";
 import cors from "cors";
 import { readFile } from "fs/promises";
 import { Config, configSchema } from "./config.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, {Express} from "express";
 import cors from "cors";
 import { readFile } from "fs/promises";
 import { Config, configSchema } from "./config.js";
@@ -11,7 +11,7 @@ import { PathLike } from "fs";
 
 configDotenv();
 
-const app = express();
+const app: Express = express();
 const port = Number(process.env.API_PORT) || 3000;
 const hostname = process.env.API_HOST || "localhost";
 


### PR DESCRIPTION
Hi, I cloned this repo and try run server in my local, but firstly an error happened

> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/zheng/Workbench/github/gpt-crawler/dist/swagger-output.json' imported from /Users/zheng/Workbench/github/gpt-crawler/dist/src/server.js
    at new NodeError (node:internal/errors:405:5)
    at finalizeResolution (node:internal/modules/esm/resolve:327:11)
    at moduleResolve (node:internal/modules/esm/resolve:946:10)
    at defaultResolve (node:internal/modules/esm/resolve:1132:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:835:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

I found in start:server script miss swagger.js generation, so I add this in script.