### PR TITLE
Account for other sitemap names

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -128,8 +128,7 @@ export async function crawl(config: Config) {
       ],
     });
 
-    const SITEMAP_SUFFIX = "sitemap.xml";
-    const isUrlASitemap = config.url.endsWith(SITEMAP_SUFFIX);
+    const isUrlASitemap = /sitemap.*\.xml$/.test(config.url);
 
     if (isUrlASitemap) {
       const listOfUrls = await downloadListOfUrls({ url: config.url });


### PR DESCRIPTION
I ran across a site that had a sitemap i wanted to crawl named `sitemap_recent.xml`

This PR changes the check for `isUrlASitemap` to the following:

```const isUrlASitemap = /sitemap.*\.xml$/.test(config.url);```

This code will set isUrlASitemap to true if config.url ends with 'sitemap' followed by any characters and then '.xml'. For example, it will match `sitemap123.xml`, `sitemap-abc.xml`, `sitemap.xml`, etc.