### PR TITLE
chore: git clone depth limit in docker

### DIFF
--- a/containerapp/Dockerfile
+++ b/containerapp/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
     sudo apt-get install nodejs -y
 
 # Install gpt-crawler
-RUN cd /home && git clone https://github.com/builderio/gpt-crawler && cd gpt-crawler && \
+RUN cd /home && git clone --depth=1 https://github.com/builderio/gpt-crawler && cd gpt-crawler && \
     npm i && \
     npx playwright install && \
     npx playwright install-deps


### PR DESCRIPTION
Hi

Inside the `containerapp/Dockerfile`, we need to add `--depth=1` when cloning the repo so that it can save on image size and time.

Thanks