### PR TITLE
feat: Customizing CSS selectors can sometimes cause web crawlers to fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ name: Pull request workflow
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
 
 permissions:
   pull-requests: read

--- a/src/core.ts
+++ b/src/core.ts
@@ -65,9 +65,8 @@ export async function crawl(config: Config) {
           );
 
           // Use custom handling for XPath selector
-          let html: string | null = null; // 初始化为null或空字符串"" 
+          let html: string | null = null; // 初始化为null或空字符串""
           if (config.selector) {
-            
             if (config.selector.startsWith("/")) {
               await waitForXPath(
                 page,
@@ -84,7 +83,9 @@ export async function crawl(config: Config) {
                 html = await getPageHtml(page, config.selector);
               } catch (error) {
                 // 如果CSS选择器等待失败，则输出日志并等待<body>
-                console.log(`CSS Selector "${config.selector}" not found. Waiting for <body> instead.`);
+                console.log(
+                  `CSS Selector "${config.selector}" not found. Waiting for <body> instead.`,
+                );
                 await page.waitForSelector("body", {
                   timeout: config.waitForSelectorTimeout ?? 1000,
                 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -65,22 +65,33 @@ export async function crawl(config: Config) {
           );
 
           // Use custom handling for XPath selector
+          let html: string | null = null; // 初始化为null或空字符串"" 
           if (config.selector) {
+            
             if (config.selector.startsWith("/")) {
               await waitForXPath(
                 page,
                 config.selector,
                 config.waitForSelectorTimeout ?? 1000,
               );
+              html = await getPageHtml(page, config.selector);
             } else {
-              await page.waitForSelector(config.selector, {
-                timeout: config.waitForSelectorTimeout ?? 1000,
-              });
+              try {
+                // 尝试等待CSS选择器，捕获可能的异常
+                await page.waitForSelector(config.selector, {
+                  timeout: config.waitForSelectorTimeout ?? 1000,
+                });
+                html = await getPageHtml(page, config.selector);
+              } catch (error) {
+                // 如果CSS选择器等待失败，则输出日志并等待<body>
+                console.log(`CSS Selector "${config.selector}" not found. Waiting for <body> instead.`);
+                await page.waitForSelector("body", {
+                  timeout: config.waitForSelectorTimeout ?? 1000,
+                });
+                html = await getPageHtml(page, "body");
+              }
             }
           }
-
-          const html = await getPageHtml(page, config.selector);
-
           // Save results as JSON to ./storage/datasets/default
           await pushData({ title, url: request.loadedUrl, html });
 


### PR DESCRIPTION
When crawling a webpage, if a custom CSS selector is selected, but the initial page does not have a suitable CSS selection object, it will cause the crawler to fail. If a custom CSS selector is not used, the truly valuable page (which can filter out a lot of useless information through the CSS selector) will have a lot more useless information, such as the "homepage". So this submission can be used when a custom CSS selector is available, and when it is not possible, use "body" as the CSS selector