### PR TITLE
feat: adding crawlee's EnqueueStrategy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [1.5.0](https://github.com/BuilderIO/gpt-crawler/compare/v1.4.0...v1.5.0) (2024-07-05)
 
-
 ### Features
 
-* git clone depth limit in docker ([87767db](https://github.com/BuilderIO/gpt-crawler/commit/87767dbda99b3259d44ec2c02dceb3a59bb2ca3c))
+- git clone depth limit in docker ([87767db](https://github.com/BuilderIO/gpt-crawler/commit/87767dbda99b3259d44ec2c02dceb3a59bb2ca3c))
 
 # [1.4.0](https://github.com/BuilderIO/gpt-crawler/compare/v1.3.0...v1.4.0) (2024-01-15)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,15 @@ export const configSchema = z.object({
    */
   exclude: z.string().or(z.array(z.string())).optional(),
   /**
+   * Set Crawlee strategy to check certain parts of the URLs found.
+   * @example "same-origin"
+   * @default "same-hostname"
+   * @see https://crawlee.dev/api/core/enum/EnqueueStrategy
+   */
+  crawlStrategy: z
+    .enum(["all", "same-origin", "same-hostname", "same-domain"])
+    .optional(),
+  /**
    * Selector to grab the inner text from
    * @example ".docs-builder-container"
    * @default ""

--- a/src/core.ts
+++ b/src/core.ts
@@ -97,6 +97,10 @@ export async function crawl(config: Config) {
               typeof config.exclude === "string"
                 ? [config.exclude]
                 : config.exclude ?? [],
+            strategy:
+              typeof config.crawlStrategy === "string"
+                ? config.crawlStrategy
+                : undefined,
           });
         },
         // Comment this option to scrape the full website.

--- a/src/core.ts
+++ b/src/core.ts
@@ -96,7 +96,7 @@ export async function crawl(config: Config) {
             exclude:
               typeof config.exclude === "string"
                 ? [config.exclude]
-                : config.exclude ?? [],
+                : (config.exclude ?? []),
             strategy:
               typeof config.crawlStrategy === "string"
                 ? config.crawlStrategy


### PR DESCRIPTION
### PR Description

**Summary:**
This pull request introduces changes to the configuration schema and the crawling logic to enhance the flexibility of the crawling strategy. For more information: https://crawlee.dev/api/core/enum/EnqueueStrategy#All
**Changes Made:**

1. **Updated Configuration Schema (`config.ts`):**
   - Added `crawlStrategy` field to the configuration schema.
     - This field allows specifying the Crawlee strategy for checking certain parts of the URLs found.
     - Possible values are `"all"`, `"same-origin"`, `"same-hostname"`, and `"same-domain"`.
     - This field is optional.

2. **Updated Crawling Logic (`core.ts`):**
   - Integrated the `crawlStrategy` configuration into the `PlaywrightCrawler` setup.
     - The `strategy` parameter in `enqueueLinks` now uses the `config.crawlStrategy` value if provided.
     - Ensures that the crawling strategy defined in the configuration is applied during the crawling process.

**Impact:**
- These changes provide greater control over the crawling behavior, allowing users to specify how URLs are handled based on their origin and domain.

**Examples:**
- When `crawlStrategy` is set to `"same-origin"`, the crawler will only follow links within the same origin.
- When `crawlStrategy` is set to `"all"`, the crawler will follow all links regardless of their origin.
