### PR TITLE
fix: correctly set cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [1.5.0](https://github.com/BuilderIO/gpt-crawler/compare/v1.4.0...v1.5.0) (2024-07-05)
 
-
 ### Features
 
-* git clone depth limit in docker ([87767db](https://github.com/BuilderIO/gpt-crawler/commit/87767dbda99b3259d44ec2c02dceb3a59bb2ca3c))
+- git clone depth limit in docker ([87767db](https://github.com/BuilderIO/gpt-crawler/commit/87767dbda99b3259d44ec2c02dceb3a59bb2ca3c))
 
 # [1.4.0](https://github.com/BuilderIO/gpt-crawler/compare/v1.3.0...v1.4.0) (2024-01-15)
 


### PR DESCRIPTION
# PR Description

## Summary
This pull request introduces the changes to crawl function. This fix the problem that crawler can't get cookies correctly.

## Changes Made
1. Update PlaywrightCrawler.preNavigationHooks in crawl function(core.ts)
    -  setting cookies before return if `RESOURCE_EXCLUSIONS` is empty. Otherwise cookies won't be set if no url excluded.
    - Use `request.url` instead of `request.loadedUrl` as cookie's url. Crawler hasn't naviagetd to the page when the hook invoked, so the `loadedUrl` would always be undefined.

## Impact
Crawler can use cookies correctly when there is no excluded urls.