### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # GPT Crawler <!-- omit from toc -->
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=de) | 
+[Español](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=es) | 
+[français](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=fr) | 
+[日本語](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=ja) | 
+[한국어](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=ko) | 
+[Português](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=pt) | 
+[Русский](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=ru) | 
+[中文](https://www.readme-i18n.com/BuilderIO/gpt-crawler?lang=zh)
+
 Crawl a site to generate knowledge files to create your own custom GPT from one or multiple URLs
 
 ![Gif showing the crawl run](https://github.com/BuilderIO/gpt-crawler/assets/844291/feb8763a-152b-4708-9c92-013b5c70d2f2)


### PR DESCRIPTION
Added links to multiple translated versions of the README, allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese. This helps improve accessibility and understanding of the project for a global audience.

The updated links can be previewed in my forked repository: https://github.com/dowithless/gpt-crawler/tree/patch-1